### PR TITLE
Fix: sheet is shown when navigating back with the keyboard open

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1347,7 +1347,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           nextPosition =
             animatedNextPositionIndex.value !== -1
               ? snapPoints[animatedNextPositionIndex.value]
-              : animatedNextPosition.value;
+              : animatedCurrentIndex.value !== -1
+              ? animatedNextPosition.value
+              : animatedClosedPosition.value;
         } else if (animatedCurrentIndex.value === -1) {
           nextPosition = animatedClosedPosition.value;
         } else if (isInTemporaryPosition.value) {


### PR DESCRIPTION


## Motivation

This MR solves the issue where the bottom sheet is open after navigating back with the keyboard open

